### PR TITLE
fixing error for ubuntu 16.04

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "capstone_rust"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Marco Milanese <marcomilanese7@gmail.com>"]
 homepage = "https://github.com/Mm7/capstone-rust"
 repository = "https://github.com/Mm7/capstone-rust"
@@ -21,4 +21,4 @@ name = "capstone_rust"
 libc = "0.2"
 
 [build-dependencies]
-bindgen = "0.20.0"
+bindgen = "0.25.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,4 @@ name = "capstone_rust"
 libc = "0.2"
 
 [build-dependencies]
-bindgen = "0.25.0"
+bindgen = "0.30.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "capstone_rust"
-version = "0.2.2"
-authors = ["Marco Milanese <marcomilanese7@gmail.com>"]
-homepage = "https://github.com/Mm7/capstone-rust"
-repository = "https://github.com/Mm7/capstone-rust"
+version = "0.2.3"
+authors = ["Marco Milanese <marcomilanese7@gmail.com>", "Alex Eubanks <endeavor@rainbowsandpwnies.com>"]
+homepage = "https://github.com/endeav0r/capstone-rust"
+repository = "https://github.com/endeav0r/capstone-rust"
 description = "A Capstone engine binding for Rust"
 keywords = ["capstone","disassembly"]
 categories = ["api-bindings"]
@@ -12,7 +12,7 @@ license = "LGPL-3.0"
 build = "build.rs"
 
 [badges]
-travis-ci = { repository = "Mm7/capstone-rust" }
+travis-ci = { repository = "endeav0r/capstone-rust" }
 
 [lib]
 name = "capstone_rust"

--- a/build.rs
+++ b/build.rs
@@ -9,6 +9,7 @@ fn main() {
     let bindings = bindgen::Builder::default()
         .header("src/wrapper.h")
         .derive_debug(true)
+        .constified_enum("cs_mode")
         .generate()
         .expect("Unable to generate bindings");
 

--- a/build.rs
+++ b/build.rs
@@ -7,8 +7,8 @@ fn main() {
     println!("cargo:rustc-link-lib=capstone");
 
     let bindings = bindgen::Builder::default()
-        .no_unstable_rust()
         .header("src/wrapper.h")
+        .derive_debug(true)
         .generate()
         .expect("Unable to generate bindings");
 

--- a/src/capstone.rs
+++ b/src/capstone.rs
@@ -101,7 +101,6 @@ fn to_res(code: cs_err) -> Result<(), CsErr> {
 ///
 /// A Rust-friendly struct to access fields of a disassembled instruction. This is a safe wrapper
 /// over cs_insn.
-#[derive(Debug)]
 pub struct Instr {
     /// Instruction ID. Find the instruction id in the '[ARCH]_insn' enum in the header file of
     /// corresponding architecture.
@@ -170,14 +169,14 @@ impl Instr {
             let arch_union = detail.__bindgen_anon_1;
 
             let arch = unsafe { match arch {
-                cs_arch::CS_ARCH_ARM   => { DetailsArch::ARM  (*arch_union.arm.as_ref())   },
-                cs_arch::CS_ARCH_ARM64 => { DetailsArch::ARM64(*arch_union.arm64.as_ref()) },
-                cs_arch::CS_ARCH_MIPS  => { DetailsArch::MIPS (*arch_union.mips.as_ref())  },
-                cs_arch::CS_ARCH_X86   => { DetailsArch::X86  (*arch_union.x86.as_ref())   },
-                cs_arch::CS_ARCH_PPC   => { DetailsArch::PPC  (*arch_union.ppc.as_ref())   },
-                cs_arch::CS_ARCH_SPARC => { DetailsArch::SPARC(*arch_union.sparc.as_ref()) },
-                cs_arch::CS_ARCH_SYSZ  => { DetailsArch::SYSZ (*arch_union.sysz.as_ref())  },
-                cs_arch::CS_ARCH_XCORE => { DetailsArch::XCORE(*arch_union.xcore.as_ref()) },
+                cs_arch::CS_ARCH_ARM   => { DetailsArch::ARM  (arch_union.arm)   },
+                cs_arch::CS_ARCH_ARM64 => { DetailsArch::ARM64(arch_union.arm64) },
+                cs_arch::CS_ARCH_MIPS  => { DetailsArch::MIPS (arch_union.mips)  },
+                cs_arch::CS_ARCH_X86   => { DetailsArch::X86  (arch_union.x86)   },
+                cs_arch::CS_ARCH_PPC   => { DetailsArch::PPC  (arch_union.ppc)   },
+                cs_arch::CS_ARCH_SPARC => { DetailsArch::SPARC(arch_union.sparc) },
+                cs_arch::CS_ARCH_SYSZ  => { DetailsArch::SYSZ (arch_union.sysz)  },
+                cs_arch::CS_ARCH_XCORE => { DetailsArch::XCORE(arch_union.xcore) },
                 _ => panic!("Unexpected arch: {:?}", arch),
             }};
 
@@ -234,7 +233,7 @@ impl Instr {
 ///     assert_eq!(insn, cs::x86_insn::X86_INS_ADD);
 /// }
 /// ```
-#[derive(Debug, PartialEq)]
+#[derive(PartialEq)]
 pub enum InstrIdArch {
     X86(x86_insn),
     ARM64(arm64_insn),
@@ -264,7 +263,6 @@ pub enum InstrIdArch {
 /// let detail = buf.get(0).unwrap().detail.unwrap(); // `buf` contains only one 'add'.
 /// assert_eq!(dec.reg_name(detail.regs_write[0]), Some("eflags"));
 /// ```
-#[derive(Debug)]
 pub struct Details {
     /// List of implicit registers read by this insn.
     pub regs_read: Vec<u32>,
@@ -280,7 +278,6 @@ pub struct Details {
 }
 
 /// Architecture-specific part of detail.
-#[derive(Debug)]
 pub enum DetailsArch {
     X86(cs_x86),
     ARM64(cs_arm64),

--- a/src/capstone.rs
+++ b/src/capstone.rs
@@ -76,7 +76,9 @@ impl Error for CsErr {
 impl CsErr {
     /// Create a Capstone error from a low-level cs_err code.
     pub fn new(code: cs_err) -> CsErr {
-        assert_ne!(code, cs_err::CS_ERR_OK);
+        // assert_ne!(code, cs_err::CS_ERR_OK);
+        // cs_err can be CS_ERR_OK is there weren't enough bytes to disassemble
+        // the instruction
         CsErr{code: code}
     }
 

--- a/src/capstone_sys.rs
+++ b/src/capstone_sys.rs
@@ -4,7 +4,6 @@
 #![allow(improper_ctypes)]
 
 use std::convert::From;
-use std::fmt;
 use std::mem::transmute;
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/src/capstone_sys.rs
+++ b/src/capstone_sys.rs
@@ -9,6 +9,23 @@ use std::mem::transmute;
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
 
+pub const CS_MODE_LITTLE_ENDIAN: cs_mode = cs_mode_CS_MODE_LITTLE_ENDIAN;
+pub const CS_MODE_ARM: cs_mode = cs_mode_CS_MODE_ARM;
+pub const CS_MODE_16: cs_mode = cs_mode_CS_MODE_16;
+pub const CS_MODE_32: cs_mode = cs_mode_CS_MODE_32;
+pub const CS_MODE_64: cs_mode = cs_mode_CS_MODE_64;
+pub const CS_MODE_THUMB: cs_mode = cs_mode_CS_MODE_THUMB;
+pub const CS_MODE_MCLASS: cs_mode = cs_mode_CS_MODE_MCLASS;
+pub const CS_MODE_V8: cs_mode = cs_mode_CS_MODE_V8;
+pub const CS_MODE_MICRO: cs_mode = cs_mode_CS_MODE_MICRO;
+pub const CS_MODE_MIPS3: cs_mode = cs_mode_CS_MODE_MIPS3;
+pub const CS_MODE_MIPS32R6: cs_mode = cs_mode_CS_MODE_MIPS32R6;
+pub const CS_MODE_MIPSGP64: cs_mode = cs_mode_CS_MODE_MIPSGP64;
+pub const CS_MODE_V9: cs_mode = cs_mode_CS_MODE_V9;
+pub const CS_MODE_BIG_ENDIAN: cs_mode = cs_mode_CS_MODE_BIG_ENDIAN;
+pub const CS_MODE_MIPS32: cs_mode = cs_mode_CS_MODE_MIPS32;
+pub const CS_MODE_MIPS64: cs_mode = cs_mode_CS_MODE_MIPS64;
+
 // Operand enum getters.
 impl cs_x86_op {
     pub fn reg(&self) -> x86_reg {

--- a/src/capstone_sys.rs
+++ b/src/capstone_sys.rs
@@ -110,7 +110,7 @@ impl cs_mips_op {
 
 impl cs_ppc_op {
     pub fn reg(&self) -> u32 {
-        return unsafe { *self.__bindgen_anon_1.reg.as_ref() };
+        return unsafe { *self.__bindgen_anon_1.reg.as_ref() as u32 };
     }
     pub fn imm(&self) -> i32 {
         return unsafe { *self.__bindgen_anon_1.imm.as_ref() };

--- a/src/capstone_sys.rs
+++ b/src/capstone_sys.rs
@@ -9,153 +9,129 @@ use std::mem::transmute;
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
-// It seems that bindgen fails to derive Debug, Clone and Copy for `cs_arm`. Let's implement them
-// manually.
-impl fmt::Debug for cs_arm {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut operands = String::new();
-        for i in self.operands.iter() {
-            operands.push_str(format!(" {:?}", i).as_str());
-        }
-
-        write!(f, "cs_arm {{ usermode: {:?}, vector_size: {:?}, vector_data: {:?}, \
-            cps_mode: {:?}, cps_flag: {:?}, cc: {:?}, update_flags: {:?}, writeback: {:?}, \
-            mem_barrier: {:?}, op_count: {:?},{}}}", self.usermode, self.vector_size,
-            self.vector_data, self.cps_mode, self.cps_flag, self.cc, self.update_flags,
-            self.writeback, self.mem_barrier, self.op_count, operands)
-    }
-}
-
-impl Clone for cs_arm {
-    fn clone(&self) -> cs_arm {
-        *self
-    }
-}
-
-impl Copy for cs_arm { }
 
 // Operand enum getters.
 impl cs_x86_op {
-    pub fn reg(&self) -> &x86_reg {
-        return unsafe { self.__bindgen_anon_1.reg.as_ref() };
+    pub fn reg(&self) -> x86_reg {
+        return unsafe { self.__bindgen_anon_1.reg };
     }
     pub fn imm(&self) -> i64 {
-        return unsafe { *self.__bindgen_anon_1.imm.as_ref() };
+        return unsafe { self.__bindgen_anon_1.imm };
     }
     pub fn fp(&self) -> f64 {
-        return unsafe { *self.__bindgen_anon_1.fp.as_ref() };
+        return unsafe { self.__bindgen_anon_1.fp };
     }
     pub fn mem(&self) -> &x86_op_mem {
-        return unsafe { self.__bindgen_anon_1.mem.as_ref() };
+        return unsafe { &self.__bindgen_anon_1.mem };
     }
 }
 
 impl cs_arm64_op {
-    pub fn reg(&self) -> u32 {
-        return unsafe { *self.__bindgen_anon_1.reg.as_ref() };
+    pub fn reg(&self) -> arm64_reg {
+        return unsafe { self.__bindgen_anon_1.reg.into() };
     }
     pub fn imm(&self) -> i64 {
-        return unsafe { *self.__bindgen_anon_1.imm.as_ref() };
+        return unsafe { self.__bindgen_anon_1.imm };
     }
     pub fn fp(&self) -> f64 {
-        return unsafe { *self.__bindgen_anon_1.fp.as_ref() };
+        return unsafe { self.__bindgen_anon_1.fp };
     }
     pub fn mem(&self) -> &arm64_op_mem {
-        return unsafe { self.__bindgen_anon_1.mem.as_ref() };
+        return unsafe { &self.__bindgen_anon_1.mem };
     }
     pub fn pstate(&self) -> &arm64_pstate {
-        return unsafe { self.__bindgen_anon_1.pstate.as_ref() };
+        return unsafe { &self.__bindgen_anon_1.pstate };
     }
     pub fn sys(&self) -> u32 {
-        return unsafe { *self.__bindgen_anon_1.sys.as_ref() };
+        return unsafe { self.__bindgen_anon_1.sys };
     }
     pub fn prefetch(&self) -> &arm64_prefetch_op {
-        return unsafe { self.__bindgen_anon_1.prefetch.as_ref() };
+        return unsafe { &self.__bindgen_anon_1.prefetch };
     }
     pub fn barrier(&self) -> &arm64_barrier_op {
-        return unsafe { self.__bindgen_anon_1.barrier.as_ref() };
+        return unsafe { &self.__bindgen_anon_1.barrier };
     }
 
 }
 
 impl cs_arm_op {
-    pub fn reg(&self) -> u32 {
-        return unsafe { *self.__bindgen_anon_1.reg.as_ref() };
+    pub fn reg(&self) -> arm_reg {
+        return unsafe { self.__bindgen_anon_1.reg.into() };
     }
     pub fn imm(&self) -> i32 {
-        return unsafe { *self.__bindgen_anon_1.imm.as_ref() };
+        return unsafe { self.__bindgen_anon_1.imm };
     }
     pub fn fp(&self) -> f64 {
-        return unsafe { *self.__bindgen_anon_1.fp.as_ref() };
+        return unsafe { self.__bindgen_anon_1.fp };
     }
     pub fn mem(&self) -> &arm_op_mem {
-        return unsafe { self.__bindgen_anon_1.mem.as_ref() };
+        return unsafe { &self.__bindgen_anon_1.mem };
     }
     pub fn setend(&self) -> &arm_setend_type {
-        return unsafe { self.__bindgen_anon_1.setend.as_ref() };
+        return unsafe { &self.__bindgen_anon_1.setend };
     }
 }
 
 impl cs_mips_op {
-    pub fn reg(&self) -> u32 {
-        return unsafe { *self.__bindgen_anon_1.reg.as_ref() };
+    pub fn reg(&self) -> mips_reg {
+        return unsafe { self.__bindgen_anon_1.reg.into() };
     }
     pub fn imm(&self) -> i64 {
-        return unsafe { *self.__bindgen_anon_1.imm.as_ref() };
+        return unsafe { self.__bindgen_anon_1.imm };
     }
     pub fn mem(&self) -> &mips_op_mem {
-        return unsafe { self.__bindgen_anon_1.mem.as_ref() };
+        return unsafe { &self.__bindgen_anon_1.mem };
     }
 }
 
 impl cs_ppc_op {
-    pub fn reg(&self) -> u32 {
-        return unsafe { *self.__bindgen_anon_1.reg.as_ref() as u32 };
+    pub fn reg(&self) -> ppc_reg {
+        return unsafe { self.__bindgen_anon_1.reg.into() };
     }
     pub fn imm(&self) -> i32 {
-        return unsafe { *self.__bindgen_anon_1.imm.as_ref() };
+        return unsafe { self.__bindgen_anon_1.imm };
     }
     pub fn mem(&self) -> &ppc_op_mem {
-        return unsafe { self.__bindgen_anon_1.mem.as_ref() };
+        return unsafe { &self.__bindgen_anon_1.mem };
     }
     pub fn crx(&self) -> &ppc_op_crx {
-        return unsafe { self.__bindgen_anon_1.crx.as_ref() };
+        return unsafe { &self.__bindgen_anon_1.crx };
     }
 }
 
 impl cs_sparc_op {
-    pub fn reg(&self) -> u32 {
-        return unsafe { *self.__bindgen_anon_1.reg.as_ref() };
+    pub fn reg(&self) -> sparc_reg {
+        return unsafe { self.__bindgen_anon_1.reg.into() };
     }
     pub fn imm(&self) -> i32 {
-        return unsafe { *self.__bindgen_anon_1.imm.as_ref() };
+        return unsafe { self.__bindgen_anon_1.imm };
     }
     pub fn mem(&self) -> &sparc_op_mem {
-        return unsafe { self.__bindgen_anon_1.mem.as_ref() };
+        return unsafe { &self.__bindgen_anon_1.mem };
     }
 }
 
 impl cs_sysz_op {
-    pub fn reg(&self) -> u32 {
-        return unsafe { *self.__bindgen_anon_1.reg.as_ref() };
+    pub fn reg(&self) -> sysz_reg {
+        return unsafe { self.__bindgen_anon_1.reg.into() };
     }
     pub fn imm(&self) -> i64 {
-        return unsafe { *self.__bindgen_anon_1.imm.as_ref() };
+        return unsafe { self.__bindgen_anon_1.imm };
     }
     pub fn mem(&self) -> &sysz_op_mem {
-        return unsafe { self.__bindgen_anon_1.mem.as_ref() };
+        return unsafe { &self.__bindgen_anon_1.mem };
     }
 }
 
 impl cs_xcore_op {
-    pub fn reg(&self) -> u32 {
-        return unsafe { *self.__bindgen_anon_1.reg.as_ref() };
+    pub fn reg(&self) -> xcore_reg {
+        return unsafe { self.__bindgen_anon_1.reg.into() };
     }
     pub fn imm(&self) -> i32 {
-        return unsafe { *self.__bindgen_anon_1.imm.as_ref() };
+        return unsafe { self.__bindgen_anon_1.imm };
     }
     pub fn mem(&self) -> &xcore_op_mem {
-        return unsafe { self.__bindgen_anon_1.mem.as_ref() };
+        return unsafe { &self.__bindgen_anon_1.mem };
     }
 }
 


### PR DESCRIPTION
In Ubuntu 16.04, bindgen detects the capstone_sys::ppc_reg enum, and because the return for this function is u32, this causes an error at compile time, and capstone_sys fails to build.

This change:
1) Adjusts for this issue.
2) Bumps the version to 0.2.2.
3) Updates to the latest version of bindgen.

capstone_rust builds fine on OSX and Ubuntu with this change.

Error from before this change given below:

```
error[E0308]: mismatched types
   --> src/capstone_sys.rs:113:25
    |
113 |         return unsafe { *self.__bindgen_anon_1.reg.as_ref() };
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected u32, found enum `capstone_sys::ppc_reg`
    |
    = note: expected type `u32`
               found type `capstone_sys::ppc_reg`
    = help: here are some functions which might fulfill your needs:
            - .as_int()

error: aborting due to previous error

```